### PR TITLE
Fixes uninitialized constant Rack::Timeout::Error

### DIFF
--- a/lib/rack/openid.rb
+++ b/lib/rack/openid.rb
@@ -134,7 +134,7 @@ module Rack
 
         url = open_id_redirect_url(req, oidreq, params)
         return redirect_to(url)
-      rescue ::OpenID::OpenIDError, Timeout::Error => e
+      rescue ::OpenID::OpenIDError, ::Timeout::Error => e
         env[RESPONSE] = MissingResponse.new
         return @app.call(env)
       end
@@ -302,7 +302,7 @@ module Rack
 
     def timeout_protection_from_identity_server
       yield
-    rescue Timeout::Error
+    rescue ::Timeout::Error
       TimeoutResponse.new
     end
   end


### PR DESCRIPTION
In an application where I'm using this gem, I'm also using the
rack-timeout gem (https://github.com/kch/rack-timeout), so use of
Timeout inside the Rack::OpenID class was finding Rack::Timeout,
which is not the same. This commit updates references to Timeout to
use the root namespace (::Timeout).
